### PR TITLE
Remove open_ssl_free_key method.

### DIFF
--- a/src/Talandis/LaravelBanklinks/Banklink/iPizza.php
+++ b/src/Talandis/LaravelBanklinks/Banklink/iPizza.php
@@ -150,7 +150,6 @@ abstract class iPizza extends Banklink
         }
 
         openssl_sign($hash, $signature, $keyId);
-        openssl_free_key($keyId);
 
         $result = base64_encode($signature);
 


### PR DESCRIPTION
PHP 8 deprecated open_ssl_free_key  method, after upgrade to php8 it crashes.